### PR TITLE
Add correct route path for spaces getFolders function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "clickup.js",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clickup.js",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "A Node.js wrapper for the Clickup API",
 	"main": "./src/index.js",
 	"dependencies": {

--- a/src/routes/Spaces.js
+++ b/src/routes/Spaces.js
@@ -64,7 +64,7 @@ class Spaces {
 	 */
 	async getFolders(spaceId, archived = false) {
 		return this._client.get({
-			endpoint: `${this.route}/${spaceId}`,
+			endpoint: `${this.route}/${spaceId}/folder`,
 			params: {
 				archived,
 			},


### PR DESCRIPTION
- changes the functions endpoint to `space/space_id/folder` as specified by the Clickup API spec.

Fixes #19 