### PR TITLE
fix: array params not being built correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "clickup.js",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clickup.js",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"description": "A Node.js wrapper for the Clickup API",
 	"main": "./src/index.js",
 	"dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -72,8 +72,7 @@ class Clickup {
 	 * @param {Object} params parameters to be converted
 	 * @private
 	 */
-	// eslint-disable-next-line class-methods-use-this
-	_buildSearchParams(params = {}) {
+	static _buildSearchParams(params = {}) {
 		return new URLSearchParams(
 			Object.entries(params).flatMap(([k, v]) => (Array.isArray(v) ? v.map((e) => [k, e]) : [[k, v]]))
 		);
@@ -89,7 +88,7 @@ class Clickup {
 	async get({ endpoint, params }) {
 		const options = {};
 		if (params) {
-			options.searchParams = this._buildSearchParams(params);
+			options.searchParams = Clickup._buildSearchParams(params);
 		}
 		return this._service.get(endpoint, options);
 	}
@@ -107,7 +106,7 @@ class Clickup {
 		const options = {};
 
 		if (params) {
-			options.searchParams = this._buildSearchParams(params);
+			options.searchParams = Clickup._buildSearchParams(params);
 		}
 
 		let contentType = this._service.defaults.options.headers['content-type'];
@@ -138,7 +137,7 @@ class Clickup {
 		const options = {};
 
 		if (params) {
-			options.searchParams = this._buildSearchParams(params);
+			options.searchParams = Clickup._buildSearchParams(params);
 		}
 
 		// json data must be sent via json property, all others are sent via body
@@ -159,7 +158,7 @@ class Clickup {
 	async delete({ endpoint, params }) {
 		const options = {};
 		if (params) {
-			options.searchParams = this._buildSearchParams(params);
+			options.searchParams = Clickup._buildSearchParams(params);
 		}
 		return this._service.delete(endpoint, options);
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,9 @@ class Clickup {
 	 */
 	// eslint-disable-next-line class-methods-use-this
 	_buildSearchParams(params = {}) {
-		return new URLSearchParams(Object.entries(params));
+		return new URLSearchParams(
+			Object.entries(params).flatMap(([k, v]) => (Array.isArray(v) ? v.map((e) => [k, e]) : [[k, v]]))
+		);
 	}
 
 	/**

--- a/test/clickup.spec.js
+++ b/test/clickup.spec.js
@@ -45,25 +45,26 @@ describe('Testing Clickup Client Instance', () => {
 	});
 });
 
-describe('Testing Clickup Class Methods', () => {
-	let clickup;
-	before(() => {
-		clickup = new Clickup(token);
-	});
-
+describe('Testing Clickup buildSearchParams Method', () => {
 	it('should return an instance of URLSearchParams', () => {
-		expect(clickup._buildSearchParams({})).instanceOf(URLSearchParams);
+		expect(Clickup._buildSearchParams({})).instanceOf(URLSearchParams);
 	});
 
 	it('should construct URLSearchParams properly from an object', () => {
 		const params = {
-			param1: 'value1',
-			param2: 'value2',
+			archive: false,
+			order_by: 'due_date',
+			'statuses[]': ['in progress', 'completed'],
 		};
 
-		const expectedOutput = new URLSearchParams({ param1: 'value1', param2: 'value2' });
+		const expectedOutput = new URLSearchParams([
+			['archived', 'false'],
+			['order_by', 'due_date'],
+			['statuses[]', 'in progress'],
+			['statuses[]', 'completed'],
+		]);
 
-		expect(clickup._buildSearchParams(params)).deep.equal(expectedOutput);
+		expect(Clickup._buildSearchParams(params)).deep.equal(expectedOutput);
 	});
 });
 


### PR DESCRIPTION
All URI parameters should be one name and one value pair, but their can be multiple parameters with the same name.

`buildSearchParams` now utilizes this behavior for array values and add a name and value pair for each element in the array.

For example
```json
"statuses[]": ["in progress", "completed"]
```
will now become
```
statuses%5B%5D=in+progress&statuses%5B%5D=completed
```

Fixes #21.