### PR TITLE
Fix and refactoring buildSearchParams function

### DIFF
--- a/src/routes/Spaces.js
+++ b/src/routes/Spaces.js
@@ -48,7 +48,7 @@ class Spaces {
 	 */
 	async delete(spaceId) {
 		return this._request.delete({
-			endpoint: `${this.route}${spaceId}`,
+			endpoint: `${this.route}/${spaceId}`,
 		});
 	}
 

--- a/src/utils/buildSearchParams.js
+++ b/src/utils/buildSearchParams.js
@@ -8,15 +8,18 @@ const buildSearchParams = (query) => {
 	const params = new URLSearchParams();
 
 	for (const key in query) {
-		if (key.endsWith('[]')) {
+		if (typeof query[key] === 'object') {
+			let rectifiedKey = key;
+			if (!editedKey.endsWith('[]')) {
+				rectifiedKey = `${key}[]`;
+			}
 			query[key].forEach((entry) => {
-				params.append(key, entry);
+				params.append(rectifiedKey, entry);
 			});
 		} else {
 			params.set(key, query[key]);
 		}
 	}
-
 	return params;
 };
 

--- a/src/utils/buildSearchParams.js
+++ b/src/utils/buildSearchParams.js
@@ -7,17 +7,23 @@
 const buildSearchParams = (query) => {
 	const params = new URLSearchParams();
 
-	for (const key in query) {
-		if (typeof query[key] === 'object') {
-			let rectifiedKey = key;
-			if (!rectifiedKey.endsWith('[]')) {
-				rectifiedKey = `${key}[]`;
+	for (let key in query) {
+		if (Object.hasOwnProperty.call(query, key)) {
+			const value = query[key];
+
+			// LHS requires array variables to be added ones per item in array
+			if (Array.isArray(value)) {
+				// LHS bracket notiation requires array keys to end with []
+				if (!key.endsWith('[]')) {
+					key += '[]';
+				}
+
+				for (const entry of value) {
+					params.append(key, entry);
+				}
+			} else {
+				params.set(key, value);
 			}
-			query[key].forEach((entry) => {
-				params.append(rectifiedKey, entry);
-			});
-		} else {
-			params.set(key, query[key]);
 		}
 	}
 	return params;

--- a/src/utils/buildSearchParams.js
+++ b/src/utils/buildSearchParams.js
@@ -10,7 +10,7 @@ const buildSearchParams = (query) => {
 	for (const key in query) {
 		if (typeof query[key] === 'object') {
 			let rectifiedKey = key;
-			if (!editedKey.endsWith('[]')) {
+			if (!rectifiedKey.endsWith('[]')) {
 				rectifiedKey = `${key}[]`;
 			}
 			query[key].forEach((entry) => {

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -13,6 +13,7 @@ describe('Testing buildSearchParams util', () => {
 			archive: false,
 			order_by: 'due_date',
 			'statuses[]': ['in progress', 'completed'],
+			assignees: [1, 2],
 		};
 
 		const expectedOutput = new URLSearchParams([
@@ -20,6 +21,8 @@ describe('Testing buildSearchParams util', () => {
 			['order_by', 'due_date'],
 			['statuses[]', 'in progress'],
 			['statuses[]', 'completed'],
+			['assignees[]', 1],
+			['assignees[]', 2],
 		]);
 
 		assert.deepEqual(buildSearchParams(params), expectedOutput);


### PR DESCRIPTION
the original code needed this structure (key as a string with square brackets):
```js
{
    "assignees[]": [
        assignId
    ]
};
```
to make the call correctly as `https://api.clickup.com/api/v2/team/{team_Id}/task?assignees[]=XXXX`.

I refactored the function to be able to use the json structure correctly, like:

```js
{
    assignees: [
        assignId
    ]
};
```